### PR TITLE
Create .eslintignore

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+template/*.js


### PR DESCRIPTION
To ignore template folder containing materialize framework so codeclimate can build with less issues