### PR TITLE
Add page title to API documentation page

### DIFF
--- a/server/api-docs/index.html
+++ b/server/api-docs/index.html
@@ -6,7 +6,7 @@
   <meta name="description" content="HelloBooks API - A Library resource which provides tracking, renting and stocking of books features">
   <meta name="author" content=" Ekundayo Abiona ">
   <meta name="keywords" content="book, read, borrow, loan">
-  <title>Swagger UI</title>
+  <title>HelloBooks API</title>
   <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,700|Source+Code+Pro:300,600|Titillium+Web:400,600,700" rel="stylesheet">
   <link rel="stylesheet" type="text/css" href="./swagger-ui.css" >
   <link rel="icon" type="image/png" href="./favicon-32x32.png" sizes="32x32" />


### PR DESCRIPTION
This makes the documentation page more descriptive and Search Engine friendly.